### PR TITLE
feat: Phase 2 — Workflows, Retries, Parallel Execution

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,7 +38,8 @@ model User {
   createdAt          DateTime @default(now())
   updatedAt          DateTime @updatedAt
 
-  tasks Task[]
+  tasks     Task[]
+  workflows Workflow[]
 
   @@map("users")
 }
@@ -77,4 +78,129 @@ model TaskLog {
 
   @@index([taskId, timestamp])
   @@map("task_logs")
+}
+
+// ── Phase 2: Workflows ──────────────────────────────
+
+enum WorkflowStatus {
+  DRAFT
+  ACTIVE
+  ARCHIVED
+}
+
+enum ExecutionStatus {
+  PENDING
+  RUNNING
+  COMPLETED
+  FAILED
+  CANCELLED
+}
+
+model Workflow {
+  id          String         @id @default(uuid())
+  name        String
+  description String?
+  status      WorkflowStatus @default(DRAFT)
+  createdAt   DateTime       @default(now())
+  updatedAt   DateTime       @updatedAt
+
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  steps      WorkflowStep[]
+  executions WorkflowExecution[]
+
+  @@index([userId])
+  @@map("workflows")
+}
+
+model WorkflowStep {
+  id            String @id @default(uuid())
+  name          String
+  prompt        String
+  agentType     String @default("claude-code")
+  positionX     Int    @default(0)
+  positionY     Int    @default(0)
+  maxRetries    Int    @default(3)
+  retryDelayMs  Int    @default(5000)
+
+  workflowId String
+  workflow   Workflow @relation(fields: [workflowId], references: [id], onDelete: Cascade)
+
+  // Dependencies: steps that must complete before this one runs
+  dependsOn  WorkflowStepDependency[] @relation("dependent")
+  dependedBy WorkflowStepDependency[] @relation("dependency")
+
+  stepExecutions StepExecution[]
+
+  @@index([workflowId])
+  @@map("workflow_steps")
+}
+
+model WorkflowStepDependency {
+  id String @id @default(uuid())
+
+  dependentStepId  String
+  dependentStep    WorkflowStep @relation("dependent", fields: [dependentStepId], references: [id], onDelete: Cascade)
+
+  dependencyStepId String
+  dependencyStep   WorkflowStep @relation("dependency", fields: [dependencyStepId], references: [id], onDelete: Cascade)
+
+  @@unique([dependentStepId, dependencyStepId])
+  @@map("workflow_step_dependencies")
+}
+
+model WorkflowExecution {
+  id          String          @id @default(uuid())
+  status      ExecutionStatus @default(PENDING)
+  startedAt   DateTime?
+  completedAt DateTime?
+  createdAt   DateTime        @default(now())
+  updatedAt   DateTime        @updatedAt
+
+  workflowId String
+  workflow   Workflow @relation(fields: [workflowId], references: [id], onDelete: Cascade)
+
+  stepExecutions StepExecution[]
+
+  @@index([workflowId, status])
+  @@map("workflow_executions")
+}
+
+model StepExecution {
+  id           String          @id @default(uuid())
+  status       ExecutionStatus @default(PENDING)
+  result       String?
+  errorMessage String?
+  attempt      Int             @default(0)
+  maxRetries   Int             @default(3)
+  retryDelayMs Int             @default(5000)
+  startedAt    DateTime?
+  completedAt  DateTime?
+  createdAt    DateTime        @default(now())
+  updatedAt    DateTime        @updatedAt
+
+  executionId String
+  execution   WorkflowExecution @relation(fields: [executionId], references: [id], onDelete: Cascade)
+
+  stepId String
+  step   WorkflowStep @relation(fields: [stepId], references: [id], onDelete: Cascade)
+
+  logs StepLog[]
+
+  @@index([executionId, status])
+  @@map("step_executions")
+}
+
+model StepLog {
+  id        String    @id @default(uuid())
+  stream    LogStream @default(STDOUT)
+  content   String
+  timestamp DateTime  @default(now())
+
+  stepExecutionId String
+  stepExecution   StepExecution @relation(fields: [stepExecutionId], references: [id], onDelete: Cascade)
+
+  @@index([stepExecutionId, timestamp])
+  @@map("step_logs")
 }

--- a/src/app/api/workflows/[id]/execute/route.ts
+++ b/src/app/api/workflows/[id]/execute/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { db } from "@/lib/db";
+import { startWorkflowExecution, getReadySteps } from "@/lib/workflow-engine";
+import { taskQueue } from "@/lib/queue";
+
+// POST /api/workflows/[id]/execute — Run a workflow
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { userId } = await auth();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id: workflowId } = await params;
+
+  const workflow = await db.workflow.findFirst({
+    where: { id: workflowId, userId },
+    include: { steps: true },
+  });
+
+  if (!workflow) return NextResponse.json({ error: "Workflow not found" }, { status: 404 });
+  if (workflow.steps.length === 0) {
+    return NextResponse.json({ error: "Workflow has no steps" }, { status: 400 });
+  }
+
+  // Check plan limits for concurrency
+  const user = await db.user.findUnique({ where: { id: userId } });
+  if (!user) return NextResponse.json({ error: "User not found" }, { status: 404 });
+
+  const runningExecutions = await db.workflowExecution.count({
+    where: { workflow: { userId }, status: "RUNNING" },
+  });
+
+  const concurrencyLimits = { FREE: 1, PRO: 5, TEAM: 20 };
+  const limit = concurrencyLimits[user.plan];
+
+  if (runningExecutions >= limit) {
+    return NextResponse.json(
+      { error: `Concurrency limit reached (${limit}). Upgrade for more parallel executions.` },
+      { status: 429 }
+    );
+  }
+
+  // Start execution
+  const execution = await startWorkflowExecution(workflowId);
+
+  // Enqueue ready steps (those with no dependencies)
+  const readySteps = await getReadySteps(execution.id);
+  for (const stepExec of readySteps) {
+    await taskQueue.add("execute-step", {
+      stepExecutionId: stepExec.id,
+      executionId: execution.id,
+      prompt: stepExec.step.prompt,
+      agentType: stepExec.step.agentType,
+    });
+  }
+
+  return NextResponse.json(execution, { status: 201 });
+}

--- a/src/app/api/workflows/[id]/executions/[executionId]/route.ts
+++ b/src/app/api/workflows/[id]/executions/[executionId]/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { db } from "@/lib/db";
+
+// GET /api/workflows/[id]/executions/[executionId] — Execution detail
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string; executionId: string }> }
+) {
+  const { userId } = await auth();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id: workflowId, executionId } = await params;
+
+  const workflow = await db.workflow.findFirst({ where: { id: workflowId, userId } });
+  if (!workflow) return NextResponse.json({ error: "Workflow not found" }, { status: 404 });
+
+  const execution = await db.workflowExecution.findFirst({
+    where: { id: executionId, workflowId },
+    include: {
+      stepExecutions: {
+        include: {
+          step: true,
+          logs: { orderBy: { timestamp: "asc" } },
+        },
+        orderBy: { createdAt: "asc" },
+      },
+    },
+  });
+
+  if (!execution) return NextResponse.json({ error: "Execution not found" }, { status: 404 });
+
+  return NextResponse.json(execution);
+}

--- a/src/app/api/workflows/[id]/route.ts
+++ b/src/app/api/workflows/[id]/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { db } from "@/lib/db";
+
+// GET /api/workflows/[id] — Workflow detail with steps and dependencies
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { userId } = await auth();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+
+  const workflow = await db.workflow.findFirst({
+    where: { id, userId },
+    include: {
+      steps: {
+        include: {
+          dependsOn: { select: { dependencyStepId: true } },
+          dependedBy: { select: { dependentStepId: true } },
+        },
+      },
+      executions: {
+        orderBy: { createdAt: "desc" },
+        take: 10,
+        include: {
+          _count: { select: { stepExecutions: true } },
+        },
+      },
+    },
+  });
+
+  if (!workflow) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  return NextResponse.json(workflow);
+}
+
+// DELETE /api/workflows/[id]
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { userId } = await auth();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+
+  const workflow = await db.workflow.findFirst({ where: { id, userId } });
+  if (!workflow) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  await db.workflow.delete({ where: { id } });
+  return NextResponse.json({ deleted: true });
+}

--- a/src/app/api/workflows/[id]/steps/route.ts
+++ b/src/app/api/workflows/[id]/steps/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { z } from "zod/v4";
+import { db } from "@/lib/db";
+
+const createStepSchema = z.object({
+  name: z.string().min(1).max(200),
+  prompt: z.string().min(1).max(10000),
+  agentType: z.string().default("claude-code"),
+  positionX: z.number().int().default(0),
+  positionY: z.number().int().default(0),
+  maxRetries: z.number().int().min(0).max(10).default(3),
+  retryDelayMs: z.number().int().min(0).max(300000).default(5000),
+  dependsOn: z.array(z.string().uuid()).default([]), // Step IDs this step depends on
+});
+
+// POST /api/workflows/[id]/steps — Add a step to a workflow
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { userId } = await auth();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id: workflowId } = await params;
+
+  const workflow = await db.workflow.findFirst({ where: { id: workflowId, userId } });
+  if (!workflow) return NextResponse.json({ error: "Workflow not found" }, { status: 404 });
+
+  const body = await req.json();
+  const parsed = createStepSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid input", details: parsed.error.issues }, { status: 400 });
+  }
+
+  const { dependsOn, ...stepData } = parsed.data;
+
+  const step = await db.workflowStep.create({
+    data: {
+      ...stepData,
+      workflowId,
+      dependsOn: dependsOn.length > 0
+        ? {
+            create: dependsOn.map((depId) => ({
+              dependencyStepId: depId,
+            })),
+          }
+        : undefined,
+    },
+    include: {
+      dependsOn: { select: { dependencyStepId: true } },
+    },
+  });
+
+  return NextResponse.json(step, { status: 201 });
+}

--- a/src/app/api/workflows/route.ts
+++ b/src/app/api/workflows/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { z } from "zod/v4";
+import { db } from "@/lib/db";
+
+const createWorkflowSchema = z.object({
+  name: z.string().min(1).max(200),
+  description: z.string().max(1000).optional(),
+});
+
+// POST /api/workflows — Create a new workflow
+export async function POST(req: NextRequest) {
+  const { userId } = await auth();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body = await req.json();
+  const parsed = createWorkflowSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid input", details: parsed.error.issues }, { status: 400 });
+  }
+
+  const workflow = await db.workflow.create({
+    data: { ...parsed.data, userId },
+  });
+
+  return NextResponse.json(workflow, { status: 201 });
+}
+
+// GET /api/workflows — List workflows
+export async function GET() {
+  const { userId } = await auth();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const workflows = await db.workflow.findMany({
+    where: { userId },
+    orderBy: { createdAt: "desc" },
+    include: {
+      _count: { select: { steps: true, executions: true } },
+    },
+  });
+
+  return NextResponse.json(workflows);
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -37,6 +37,15 @@ export default function DashboardLayout({
             </svg>
             Tasks
           </Link>
+          <Link
+            href="/dashboard/workflows"
+            className="flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium text-neutral-700 hover:bg-neutral-100 transition-colors"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+            </svg>
+            Workflows
+          </Link>
         </nav>
         <div className="p-4 border-t border-neutral-200">
           <div className="flex items-center gap-3">

--- a/src/app/dashboard/workflows/[id]/add-step-form.tsx
+++ b/src/app/dashboard/workflows/[id]/add-step-form.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+
+export function AddStepForm({
+  workflowId,
+  existingSteps,
+}: {
+  workflowId: string;
+  existingSteps: Array<{ id: string; name: string }>;
+}) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedDeps, setSelectedDeps] = useState<string[]>([]);
+  const router = useRouter();
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    const formData = new FormData(e.currentTarget);
+    const name = formData.get("name") as string;
+    const prompt = formData.get("prompt") as string;
+    const maxRetries = parseInt(formData.get("maxRetries") as string) || 3;
+
+    try {
+      const res = await fetch(`/api/workflows/${workflowId}/steps`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name,
+          prompt,
+          maxRetries,
+          dependsOn: selectedDeps,
+          positionY: existingSteps.length,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error || "Failed to add step");
+        return;
+      }
+
+      setSelectedDeps([]);
+      (e.target as HTMLFormElement).reset();
+      router.refresh();
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function toggleDep(stepId: string) {
+    setSelectedDeps((prev) =>
+      prev.includes(stepId)
+        ? prev.filter((id) => id !== stepId)
+        : [...prev, stepId]
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium text-neutral-500">
+          Add Step
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <Label htmlFor="step-name">Step Name</Label>
+              <Input
+                id="step-name"
+                name="name"
+                placeholder="e.g., Run tests"
+                required
+              />
+            </div>
+            <div>
+              <Label htmlFor="maxRetries">Max Retries</Label>
+              <Input
+                id="maxRetries"
+                name="maxRetries"
+                type="number"
+                min="0"
+                max="10"
+                defaultValue="3"
+              />
+            </div>
+          </div>
+          <div>
+            <Label htmlFor="step-prompt">Prompt</Label>
+            <Textarea
+              id="step-prompt"
+              name="prompt"
+              placeholder="What should the agent do in this step?"
+              rows={3}
+              required
+            />
+          </div>
+          {existingSteps.length > 0 && (
+            <div>
+              <Label>Depends on (optional)</Label>
+              <div className="flex flex-wrap gap-2 mt-1">
+                {existingSteps.map((step) => (
+                  <button
+                    key={step.id}
+                    type="button"
+                    onClick={() => toggleDep(step.id)}
+                    className={`px-3 py-1 text-xs rounded-full border transition-colors ${
+                      selectedDeps.includes(step.id)
+                        ? "bg-orange-500 text-white border-orange-500"
+                        : "bg-white text-neutral-600 border-neutral-200 hover:border-orange-300"
+                    }`}
+                  >
+                    {step.name}
+                  </button>
+                ))}
+              </div>
+              <p className="text-xs text-neutral-400 mt-1">
+                Selected steps must complete before this step runs
+              </p>
+            </div>
+          )}
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          <Button
+            type="submit"
+            disabled={loading}
+            className="bg-orange-500 hover:bg-orange-600 text-white"
+          >
+            {loading ? "Adding..." : "Add Step"}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/dashboard/workflows/[id]/execution-list.tsx
+++ b/src/app/dashboard/workflows/[id]/execution-list.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+
+interface StepExecution {
+  id: string;
+  status: string;
+  attempt: number;
+  maxRetries: number;
+  startedAt: Date | string | null;
+  completedAt: Date | string | null;
+  errorMessage: string | null;
+  step: { name: string };
+}
+
+interface Execution {
+  id: string;
+  status: string;
+  startedAt: Date | string | null;
+  completedAt: Date | string | null;
+  createdAt: Date | string;
+  stepExecutions: StepExecution[];
+}
+
+export function ExecutionList({
+  workflowId,
+  executions,
+  statusColors,
+}: {
+  workflowId: string;
+  executions: Execution[];
+  statusColors: Record<string, string>;
+}) {
+  if (executions.length === 0) {
+    return (
+      <div className="text-center py-8 text-neutral-400">
+        No executions yet. Run the workflow to see results here.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {executions.map((exec) => {
+        const duration =
+          exec.startedAt && exec.completedAt
+            ? `${((new Date(exec.completedAt).getTime() - new Date(exec.startedAt).getTime()) / 1000).toFixed(1)}s`
+            : exec.startedAt
+              ? "Running..."
+              : "—";
+
+        return (
+          <Card key={exec.id}>
+            <CardContent className="py-4">
+              <div className="flex items-center justify-between mb-3">
+                <div className="flex items-center gap-3">
+                  <Badge variant="secondary" className={statusColors[exec.status] || ""}>
+                    {exec.status}
+                  </Badge>
+                  <span className="text-xs text-neutral-400 font-mono">
+                    {exec.id.slice(0, 8)}
+                  </span>
+                </div>
+                <div className="flex items-center gap-3 text-xs text-neutral-500">
+                  <span>{duration}</span>
+                  <span>{new Date(exec.createdAt).toLocaleString()}</span>
+                </div>
+              </div>
+
+              {/* Step execution progress */}
+              <div className="flex gap-1">
+                {exec.stepExecutions.map((se) => (
+                  <div
+                    key={se.id}
+                    className="flex-1 group relative"
+                    title={`${se.step.name}: ${se.status}${se.errorMessage ? ` — ${se.errorMessage}` : ""}`}
+                  >
+                    <div
+                      className={`h-2 rounded-full ${
+                        se.status === "COMPLETED"
+                          ? "bg-green-500"
+                          : se.status === "RUNNING"
+                            ? "bg-orange-500 animate-pulse"
+                            : se.status === "FAILED"
+                              ? "bg-red-500"
+                              : "bg-neutral-200"
+                      }`}
+                    />
+                    <span className="text-[10px] text-neutral-400 mt-1 block truncate">
+                      {se.step.name}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/dashboard/workflows/[id]/page.tsx
+++ b/src/app/dashboard/workflows/[id]/page.tsx
@@ -1,0 +1,149 @@
+import { redirect, notFound } from "next/navigation";
+import Link from "next/link";
+import { db } from "@/lib/db";
+import { getOrCreateUser } from "@/lib/auth";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { AddStepForm } from "./add-step-form";
+import { RunWorkflowButton } from "./run-workflow-button";
+import { ExecutionList } from "./execution-list";
+
+const statusColors: Record<string, string> = {
+  DRAFT: "bg-neutral-100 text-neutral-700",
+  ACTIVE: "bg-green-100 text-green-700",
+  ARCHIVED: "bg-neutral-100 text-neutral-400",
+  PENDING: "bg-neutral-100 text-neutral-700",
+  RUNNING: "bg-orange-100 text-orange-700",
+  COMPLETED: "bg-green-100 text-green-700",
+  FAILED: "bg-red-100 text-red-700",
+};
+
+export default async function WorkflowDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const user = await getOrCreateUser();
+  if (!user) redirect("/sign-in");
+
+  const { id } = await params;
+
+  const workflow = await db.workflow.findFirst({
+    where: { id, userId: user.id },
+    include: {
+      steps: {
+        include: {
+          dependsOn: {
+            include: { dependencyStep: { select: { id: true, name: true } } },
+          },
+        },
+        orderBy: { positionY: "asc" },
+      },
+      executions: {
+        orderBy: { createdAt: "desc" },
+        take: 10,
+        include: {
+          stepExecutions: {
+            include: { step: { select: { name: true } } },
+          },
+        },
+      },
+    },
+  });
+
+  if (!workflow) notFound();
+
+  return (
+    <div>
+      <div className="mb-6">
+        <Link
+          href="/dashboard/workflows"
+          className="text-sm text-neutral-500 hover:text-neutral-700 transition-colors"
+        >
+          &larr; Back to Workflows
+        </Link>
+      </div>
+
+      <div className="flex items-start justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-neutral-900">{workflow.name}</h1>
+          {workflow.description && (
+            <p className="text-neutral-500 mt-1">{workflow.description}</p>
+          )}
+          <div className="flex items-center gap-3 mt-2">
+            <Badge variant="secondary" className={statusColors[workflow.status]}>
+              {workflow.status}
+            </Badge>
+            <span className="text-sm text-neutral-500">
+              {workflow.steps.length} step{workflow.steps.length !== 1 ? "s" : ""}
+            </span>
+          </div>
+        </div>
+        {workflow.steps.length > 0 && (
+          <RunWorkflowButton workflowId={workflow.id} />
+        )}
+      </div>
+
+      {/* Steps */}
+      <h2 className="text-lg font-semibold text-neutral-900 mb-4">Steps</h2>
+      {workflow.steps.length === 0 ? (
+        <Card className="mb-6">
+          <CardContent className="py-8 text-center text-neutral-400">
+            No steps yet. Add your first step below.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-3 mb-6">
+          {workflow.steps.map((step, idx) => (
+            <Card key={step.id}>
+              <CardHeader className="pb-2">
+                <div className="flex items-center justify-between">
+                  <CardTitle className="text-sm font-medium">
+                    <span className="text-orange-500 mr-2">#{idx + 1}</span>
+                    {step.name}
+                  </CardTitle>
+                  <div className="flex items-center gap-2 text-xs text-neutral-400">
+                    <span>{step.agentType}</span>
+                    <span>·</span>
+                    <span>{step.maxRetries} retries</span>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-neutral-600 whitespace-pre-wrap line-clamp-2">
+                  {step.prompt}
+                </p>
+                {step.dependsOn.length > 0 && (
+                  <div className="mt-2 flex items-center gap-1 text-xs text-neutral-400">
+                    <span>Depends on:</span>
+                    {step.dependsOn.map((dep) => (
+                      <Badge key={dep.id} variant="secondary" className="text-xs">
+                        {dep.dependencyStep.name}
+                      </Badge>
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      <AddStepForm
+        workflowId={workflow.id}
+        existingSteps={workflow.steps.map((s) => ({ id: s.id, name: s.name }))}
+      />
+
+      <Separator className="my-8" />
+
+      {/* Executions */}
+      <h2 className="text-lg font-semibold text-neutral-900 mb-4">Executions</h2>
+      <ExecutionList
+        workflowId={workflow.id}
+        executions={workflow.executions}
+        statusColors={statusColors}
+      />
+    </div>
+  );
+}

--- a/src/app/dashboard/workflows/[id]/run-workflow-button.tsx
+++ b/src/app/dashboard/workflows/[id]/run-workflow-button.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+
+export function RunWorkflowButton({ workflowId }: { workflowId: string }) {
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  async function handleRun() {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/workflows/${workflowId}/execute`, {
+        method: "POST",
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        alert(data.error || "Failed to run workflow");
+        return;
+      }
+      router.refresh();
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Button
+      onClick={handleRun}
+      disabled={loading}
+      className="bg-orange-500 hover:bg-orange-600 text-white"
+    >
+      {loading ? "Starting..." : "Run Workflow"}
+    </Button>
+  );
+}

--- a/src/app/dashboard/workflows/create-workflow-dialog.tsx
+++ b/src/app/dashboard/workflows/create-workflow-dialog.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+
+export function CreateWorkflowDialog() {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    const formData = new FormData(e.currentTarget);
+    const name = formData.get("name") as string;
+    const description = formData.get("description") as string;
+
+    try {
+      const res = await fetch("/api/workflows", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, description: description || undefined }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error || "Failed to create workflow");
+        return;
+      }
+
+      const workflow = await res.json();
+      setOpen(false);
+      router.push(`/dashboard/workflows/${workflow.id}`);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger
+        render={<Button className="bg-orange-500 hover:bg-orange-600 text-white" />}
+      >
+        New Workflow
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create Workflow</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <Label htmlFor="name">Workflow Name</Label>
+            <Input
+              id="name"
+              name="name"
+              placeholder="e.g., Deploy pipeline"
+              required
+            />
+          </div>
+          <div>
+            <Label htmlFor="description">Description (optional)</Label>
+            <Textarea
+              id="description"
+              name="description"
+              placeholder="What does this workflow do?"
+              rows={2}
+            />
+          </div>
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          <Button
+            type="submit"
+            disabled={loading}
+            className="w-full bg-orange-500 hover:bg-orange-600 text-white"
+          >
+            {loading ? "Creating..." : "Create Workflow"}
+          </Button>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/dashboard/workflows/page.tsx
+++ b/src/app/dashboard/workflows/page.tsx
@@ -1,0 +1,93 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { db } from "@/lib/db";
+import { getOrCreateUser } from "@/lib/auth";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { CreateWorkflowDialog } from "./create-workflow-dialog";
+
+const statusColors: Record<string, string> = {
+  DRAFT: "bg-neutral-100 text-neutral-700",
+  ACTIVE: "bg-green-100 text-green-700",
+  ARCHIVED: "bg-neutral-100 text-neutral-400",
+};
+
+export default async function WorkflowsPage() {
+  const user = await getOrCreateUser();
+  if (!user) redirect("/sign-in");
+
+  const workflows = await db.workflow.findMany({
+    where: { userId: user.id },
+    orderBy: { createdAt: "desc" },
+    include: {
+      _count: { select: { steps: true, executions: true } },
+    },
+  });
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-8">
+        <div>
+          <h1 className="text-2xl font-bold text-neutral-900">Workflows</h1>
+          <p className="text-neutral-500 mt-1">Chain tasks into automated pipelines</p>
+        </div>
+        <CreateWorkflowDialog />
+      </div>
+
+      {workflows.length === 0 ? (
+        <div className="text-center py-16 text-neutral-400">
+          <p className="text-lg font-medium">No workflows yet</p>
+          <p className="text-sm mt-1">Create a workflow to chain tasks together</p>
+        </div>
+      ) : (
+        <div className="border rounded-lg">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Steps</TableHead>
+                <TableHead>Executions</TableHead>
+                <TableHead>Created</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {workflows.map((wf) => (
+                <TableRow key={wf.id}>
+                  <TableCell>
+                    <Link
+                      href={`/dashboard/workflows/${wf.id}`}
+                      className="font-medium text-neutral-900 hover:text-orange-600 transition-colors"
+                    >
+                      {wf.name}
+                    </Link>
+                    {wf.description && (
+                      <p className="text-xs text-neutral-400 mt-0.5">{wf.description}</p>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant="secondary" className={statusColors[wf.status]}>
+                      {wf.status}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-neutral-500">{wf._count.steps}</TableCell>
+                  <TableCell className="text-neutral-500">{wf._count.executions}</TableCell>
+                  <TableCell className="text-neutral-500">
+                    {wf.createdAt.toLocaleDateString()}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/workflow-engine.ts
+++ b/src/lib/workflow-engine.ts
@@ -1,0 +1,118 @@
+import { db } from "./db";
+
+/**
+ * Workflow Execution Engine
+ *
+ * Resolves the DAG and determines which steps are ready to run.
+ * A step is "ready" when all its dependencies have completed successfully.
+ */
+
+export async function getReadySteps(executionId: string) {
+  const execution = await db.workflowExecution.findUnique({
+    where: { id: executionId },
+    include: {
+      stepExecutions: {
+        include: {
+          step: {
+            include: {
+              dependsOn: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!execution) throw new Error(`Execution ${executionId} not found`);
+
+  const readySteps: typeof execution.stepExecutions = [];
+
+  for (const stepExec of execution.stepExecutions) {
+    // Skip if already running, completed, or failed beyond retries
+    if (stepExec.status !== "PENDING") continue;
+
+    const dependencyStepIds = stepExec.step.dependsOn.map((d) => d.dependencyStepId);
+
+    if (dependencyStepIds.length === 0) {
+      // No dependencies — ready to run
+      readySteps.push(stepExec);
+      continue;
+    }
+
+    // Check if all dependencies are completed
+    const depExecutions = execution.stepExecutions.filter((se) =>
+      dependencyStepIds.includes(se.stepId)
+    );
+
+    const allDepsCompleted = depExecutions.every((de) => de.status === "COMPLETED");
+    const anyDepFailed = depExecutions.some((de) => de.status === "FAILED");
+
+    if (allDepsCompleted) {
+      readySteps.push(stepExec);
+    } else if (anyDepFailed) {
+      // Dependency failed — mark this step as failed too
+      await db.stepExecution.update({
+        where: { id: stepExec.id },
+        data: {
+          status: "FAILED",
+          errorMessage: "Dependency step failed",
+          completedAt: new Date(),
+        },
+      });
+    }
+  }
+
+  return readySteps;
+}
+
+export async function checkExecutionComplete(executionId: string) {
+  const stepExecutions = await db.stepExecution.findMany({
+    where: { executionId },
+  });
+
+  const allDone = stepExecutions.every(
+    (se) => se.status === "COMPLETED" || se.status === "FAILED"
+  );
+
+  if (!allDone) return;
+
+  const anyFailed = stepExecutions.some((se) => se.status === "FAILED");
+
+  await db.workflowExecution.update({
+    where: { id: executionId },
+    data: {
+      status: anyFailed ? "FAILED" : "COMPLETED",
+      completedAt: new Date(),
+    },
+  });
+}
+
+export async function startWorkflowExecution(workflowId: string) {
+  const workflow = await db.workflow.findUnique({
+    where: { id: workflowId },
+    include: { steps: true },
+  });
+
+  if (!workflow) throw new Error(`Workflow ${workflowId} not found`);
+  if (workflow.steps.length === 0) throw new Error("Workflow has no steps");
+
+  // Create execution + step executions
+  const execution = await db.workflowExecution.create({
+    data: {
+      workflowId,
+      status: "RUNNING",
+      startedAt: new Date(),
+      stepExecutions: {
+        create: workflow.steps.map((step) => ({
+          stepId: step.id,
+          status: "PENDING",
+          maxRetries: step.maxRetries,
+          retryDelayMs: step.retryDelayMs,
+        })),
+      },
+    },
+    include: { stepExecutions: true },
+  });
+
+  return execution;
+}

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -18,54 +18,210 @@ const agents: Record<string, AgentProvider> = {
   "claude-code": new ClaudeCodeProvider(),
 };
 
+// ── Task Worker (Phase 1 — standalone tasks) ────────
+
 interface TaskJobData {
   taskId: string;
   prompt: string;
   agentType: string;
 }
 
-const worker = new Worker<TaskJobData>(
-  "task-execution",
-  async (job: Job<TaskJobData>) => {
-    const { taskId, prompt, agentType } = job.data;
+async function processTask(job: Job<TaskJobData>) {
+  const { taskId, prompt, agentType } = job.data;
 
-    const agent = agents[agentType];
-    if (!agent) {
-      await db.task.update({
-        where: { id: taskId },
-        data: { status: "FAILED", errorMessage: `Unknown agent type: ${agentType}` },
-      });
-      return;
-    }
-
-    // Mark as running
+  const agent = agents[agentType];
+  if (!agent) {
     await db.task.update({
       where: { id: taskId },
-      data: { status: "RUNNING", startedAt: new Date() },
+      data: { status: "FAILED", errorMessage: `Unknown agent type: ${agentType}` },
     });
+    return;
+  }
 
-    const onLog = async (stream: "stdout" | "stderr" | "system", content: string) => {
-      const streamMap = { stdout: "STDOUT", stderr: "STDERR", system: "SYSTEM" } as const;
-      await db.taskLog.create({
-        data: {
-          taskId,
-          stream: streamMap[stream],
-          content,
-        },
+  await db.task.update({
+    where: { id: taskId },
+    data: { status: "RUNNING", startedAt: new Date() },
+  });
+
+  const onLog = async (stream: "stdout" | "stderr" | "system", content: string) => {
+    const streamMap = { stdout: "STDOUT", stderr: "STDERR", system: "SYSTEM" } as const;
+    await db.taskLog.create({
+      data: { taskId, stream: streamMap[stream], content },
+    });
+  };
+
+  const result = await agent.execute(prompt, onLog);
+
+  await db.task.update({
+    where: { id: taskId },
+    data: {
+      status: result.success ? "COMPLETED" : "FAILED",
+      result: result.output || null,
+      errorMessage: result.error || null,
+      completedAt: new Date(),
+    },
+  });
+}
+
+// ── Step Worker (Phase 2 — workflow steps with retry) ────────
+
+interface StepJobData {
+  stepExecutionId: string;
+  executionId: string;
+  prompt: string;
+  agentType: string;
+}
+
+async function processStep(job: Job<StepJobData>) {
+  const { stepExecutionId, executionId, prompt, agentType } = job.data;
+
+  const agent = agents[agentType];
+  if (!agent) {
+    await db.stepExecution.update({
+      where: { id: stepExecutionId },
+      data: { status: "FAILED", errorMessage: `Unknown agent type: ${agentType}`, completedAt: new Date() },
+    });
+    await checkAndAdvance(executionId);
+    return;
+  }
+
+  const stepExec = await db.stepExecution.findUnique({ where: { id: stepExecutionId } });
+  if (!stepExec) return;
+
+  // Mark running
+  await db.stepExecution.update({
+    where: { id: stepExecutionId },
+    data: {
+      status: "RUNNING",
+      startedAt: new Date(),
+      attempt: stepExec.attempt + 1,
+    },
+  });
+
+  const onLog = async (stream: "stdout" | "stderr" | "system", content: string) => {
+    const streamMap = { stdout: "STDOUT", stderr: "STDERR", system: "SYSTEM" } as const;
+    await db.stepLog.create({
+      data: { stepExecutionId, stream: streamMap[stream], content },
+    });
+  };
+
+  const result = await agent.execute(prompt, onLog);
+
+  if (result.success) {
+    await db.stepExecution.update({
+      where: { id: stepExecutionId },
+      data: { status: "COMPLETED", result: result.output || null, completedAt: new Date() },
+    });
+    await checkAndAdvance(executionId);
+  } else {
+    // Retry logic
+    const currentAttempt = stepExec.attempt + 1;
+    if (currentAttempt < stepExec.maxRetries) {
+      const delay = stepExec.retryDelayMs * Math.pow(2, currentAttempt - 1); // exponential backoff
+      await onLog("system", `Step failed (attempt ${currentAttempt}/${stepExec.maxRetries}). Retrying in ${delay}ms...`);
+
+      await db.stepExecution.update({
+        where: { id: stepExecutionId },
+        data: { status: "PENDING", errorMessage: result.error || null },
       });
-    };
 
-    const result = await agent.execute(prompt, onLog);
+      // Re-enqueue with delay
+      const { Queue } = await import("bullmq");
+      const retryQueue = new Queue("task-execution", { connection: redisConnection });
+      await retryQueue.add("execute-step", job.data, { delay });
+      await retryQueue.close();
+    } else {
+      await onLog("system", `Step failed after ${currentAttempt} attempts. Giving up.`);
+      await db.stepExecution.update({
+        where: { id: stepExecutionId },
+        data: { status: "FAILED", errorMessage: result.error || null, completedAt: new Date() },
+      });
+      await checkAndAdvance(executionId);
+    }
+  }
+}
 
-    await db.task.update({
-      where: { id: taskId },
+/**
+ * After a step completes/fails, check if there are new steps ready to run
+ * or if the entire execution is done.
+ */
+async function checkAndAdvance(executionId: string) {
+  const stepExecutions = await db.stepExecution.findMany({
+    where: { executionId },
+    include: {
+      step: {
+        include: { dependsOn: true },
+      },
+    },
+  });
+
+  const allDone = stepExecutions.every(
+    (se) => se.status === "COMPLETED" || se.status === "FAILED"
+  );
+
+  if (allDone) {
+    const anyFailed = stepExecutions.some((se) => se.status === "FAILED");
+    await db.workflowExecution.update({
+      where: { id: executionId },
       data: {
-        status: result.success ? "COMPLETED" : "FAILED",
-        result: result.output || null,
-        errorMessage: result.error || null,
+        status: anyFailed ? "FAILED" : "COMPLETED",
         completedAt: new Date(),
       },
     });
+    console.log(`[worker] Workflow execution ${executionId} ${anyFailed ? "FAILED" : "COMPLETED"}`);
+    return;
+  }
+
+  // Find pending steps whose dependencies are all completed
+  for (const stepExec of stepExecutions) {
+    if (stepExec.status !== "PENDING") continue;
+
+    const depIds = stepExec.step.dependsOn.map((d) => d.dependencyStepId);
+
+    if (depIds.length === 0) continue; // Already enqueued at start
+
+    const depExecs = stepExecutions.filter((se) => depIds.includes(se.stepId));
+    const allDepsCompleted = depExecs.every((de) => de.status === "COMPLETED");
+    const anyDepFailed = depExecs.some((de) => de.status === "FAILED");
+
+    if (allDepsCompleted) {
+      // Enqueue this step
+      await worker.client.then((queue) => {
+        // Can't easily access queue from worker, so use a workaround
+      });
+      // Direct enqueue via new Queue reference
+      const { Queue } = await import("bullmq");
+      const q = new Queue("task-execution", { connection: redisConnection });
+      await q.add("execute-step", {
+        stepExecutionId: stepExec.id,
+        executionId,
+        prompt: stepExec.step.prompt,
+        agentType: stepExec.step.agentType,
+      });
+      await q.close();
+    } else if (anyDepFailed) {
+      await db.stepExecution.update({
+        where: { id: stepExec.id },
+        data: {
+          status: "FAILED",
+          errorMessage: "Dependency step failed",
+          completedAt: new Date(),
+        },
+      });
+    }
+  }
+}
+
+// ── Worker Setup ────────
+
+const worker = new Worker(
+  "task-execution",
+  async (job: Job) => {
+    if (job.name === "execute-step") {
+      await processStep(job as Job<StepJobData>);
+    } else {
+      await processTask(job as Job<TaskJobData>);
+    }
   },
   {
     connection: redisConnection,
@@ -74,11 +230,11 @@ const worker = new Worker<TaskJobData>(
 );
 
 worker.on("completed", (job) => {
-  console.log(`[worker] Task ${job.data.taskId} completed`);
+  console.log(`[worker] Job ${job.name} completed`);
 });
 
 worker.on("failed", (job, err) => {
-  console.error(`[worker] Task ${job?.data.taskId} failed:`, err.message);
+  console.error(`[worker] Job ${job?.name} failed:`, err.message);
 });
 
-console.log("[worker] Task execution worker started");
+console.log("[worker] Task execution worker started (Phase 1 + Phase 2)");


### PR DESCRIPTION
## Summary
Complete Phase 2: workflow system with DAG-based execution, retry logic, and parallel step processing.

### What's new
- **Workflow model**: Create named workflows, add steps with prompts, define dependencies between steps
- **DAG execution engine**: Steps run in parallel when their dependencies are met. If Step A → (B, C) → D, then B and C run simultaneously after A completes, D runs after both finish
- **Retry with exponential backoff**: Each step has configurable `maxRetries` (default 3) and `retryDelayMs` (default 5s). Delay doubles on each retry attempt
- **Cascade failure**: If a step fails beyond retries, all downstream steps are marked failed
- **Concurrency limits**: Free=1, Pro=5, Team=20 concurrent workflow executions
- **Full UI**: Workflow list, detail page with step builder, dependency picker (click to select which steps must complete first), run button, execution history with progress bars

### New API endpoints
| Method | Path | Description |
|--------|------|-------------|
| POST | `/api/workflows` | Create workflow |
| GET | `/api/workflows` | List workflows |
| GET | `/api/workflows/[id]` | Workflow detail |
| DELETE | `/api/workflows/[id]` | Delete workflow |
| POST | `/api/workflows/[id]/steps` | Add step with dependencies |
| POST | `/api/workflows/[id]/execute` | Run workflow |
| GET | `/api/workflows/[id]/executions/[execId]` | Execution detail |

## Test plan
- [ ] Create a workflow with 3+ steps
- [ ] Set up dependencies (A → B, A → C, B+C → D)
- [ ] Run workflow — verify A runs first, B+C in parallel, D after both
- [ ] Force a step to fail — verify retry with backoff
- [ ] Verify cascade failure when retries exhausted
- [ ] Check concurrency limit returns 429

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)